### PR TITLE
Initial roles write up

### DIFF
--- a/governance/community_roles.md
+++ b/governance/community_roles.md
@@ -12,7 +12,7 @@ Madalyn Hardaker
 *Head of eResearch Data Governance, King’s College London*
 
 Simon Li
-*Software and Operations Engineer, University of Dundee*
+*Senior Research Infrastructure Engineer*
 
 David Sarmiento Perez
 *Research Project Manager, The Alan Turing Institute*

--- a/governance/community_roles.md
+++ b/governance/community_roles.md
@@ -25,10 +25,13 @@ Balint Stewart
 
 ## Responsibilities
 ### Co-chairs
-* Management of the [UK TRE Community mailbox](mailto:uktrecommunity@gmail.com)
-* Management of the UK TRE Community [GitHub organisation](https://github.com/uk-tre)
-* Management of the UK TRE Community [Google Drive](https://drive.google.com/drive/folders/1yH05sKEZxvHqQwjEkUDIsQdPDMZxY_g2?usp=sharing)
-* Management of the UK TRE Community [Jisc mailing list](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-COMM&A=1)
-* Management of the UK TRE Community [Slack workspace](https://join.slack.com/t/uktrecommunity/shared_invite/zt-26r7jz25d-J5iV0XoqyLepEiKk4XpJVg)
+- Management of the [UK TRE Community mailbox](mailto:uktrecommunity@gmail.com)
+- Management of the UK TRE Community [GitHub organisation](https://github.com/uk-tre)
+- Management of the UK TRE Community internal Google Drivehttps://drive.google.com/drive/folders/1yH05sKEZxvHqQwjEkUDIsQdPDMZxY_g2?usp=sharing
+- Management of the UK TRE Community [Jisc mailing list](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-COMM&A=1)
+- Management of the UK TRE Community [Slack workspace](https://join.slack.com/t/uktrecommunity/shared_invite/zt-26r7jz25d-J5iV0XoqyLepEiKk4XpJVg)
+- Attendance at Community Management meetings, Tuesdays 11:00 - 11:45
 
 ## Becoming chair or co-chair
+
+TBC

--- a/governance/community_roles.md
+++ b/governance/community_roles.md
@@ -1,0 +1,34 @@
+# Community roles
+
+This file lays out the key roles within the UK TRE Community, including who currently holds them, their responsibilities, and how these roles are decided.
+
+## Current positions
+
+**Co-chairs**:
+Lucy Cheesman
+*Research Data Services Manager, University of Sheffield*
+
+Madalyn Hardaker
+*Head of eResearch Data Governance, King’s College London*
+
+Simon Li
+*Software and Operations Engineer, University of Dundee*
+
+David Sarmiento Perez
+*Research Project Manager, The Alan Turing Institute*
+
+Hari Sood
+*Research Application Manager, Alan Turing Institute*
+
+Balint Stewart
+*Programme Manager, DARE UK*
+
+## Responsibilities
+### Co-chairs
+* Management of the [UK TRE Community mailbox](mailto:uktrecommunity@gmail.com)
+* Management of the UK TRE Community [GitHub organisation](https://github.com/uk-tre)
+* Management of the UK TRE Community [Google Drive](https://drive.google.com/drive/folders/1yH05sKEZxvHqQwjEkUDIsQdPDMZxY_g2?usp=sharing)
+* Management of the UK TRE Community [Jisc mailing list](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-COMM&A=1)
+* Management of the UK TRE Community [Slack workspace](https://join.slack.com/t/uktrecommunity/shared_invite/zt-26r7jz25d-J5iV0XoqyLepEiKk4XpJVg)
+
+## Becoming chair or co-chair


### PR DESCRIPTION
Answers #6 

I think there are still some questions, namely:
- Do we want to separate out 'owners' (direct access to everything, e.g. the uktre google account) from 'administrators' (those who can admin access to all places but not direct access). This is @manics of not sharing the root details too much, where we discussed him and I have owner access, everyone else has admin access. 
- We need to think of a process for nominating and stepping down from being co-chairs, and also whether we want any other roles in the community